### PR TITLE
Fix: don't add empty file extension

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,11 @@ fn main() -> std::io::Result<()> {
                 Some(t) => t,
                 None => "",
             };
-            new_dest_file = format!("{}_uniq.{}", out_file_stem, ext);
+            if ext.is_empty() {
+                new_dest_file = format!("{}_uniq", out_file_stem);
+            } else {
+                new_dest_file = format!("{}_uniq.{}", out_file_stem, ext);
+            }
             ""
         }
     };


### PR DESCRIPTION
When no file extension and no destination file is given, the program does not create an empty file extension. (fixes #3)
